### PR TITLE
Don't remove the get-dependency package mirror lists

### DIFF
--- a/Rules
+++ b/Rules
@@ -15,6 +15,8 @@
 
 passthrough '/style/'
 passthrough '/get-dependency/'
+passthrough '/packages/'
+passthrough '/packages/*/'
 passthrough '/releases/'
 passthrough '/releases/*/'
 


### PR DESCRIPTION
fixed it manually for http://openra.res0l.net/ already because it was urgent.
