### PR TITLE
deploy with nanoc and do a dry run using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ install:
 script:
  - nanoc compile
 
+after_success:
+ - gem install systemu
+ - nanoc deploy --target res0l --dry-run
+
 # Only watch the production branch.
 branches:
  only:

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -75,3 +75,8 @@ watcher:
   # When to send notifications (using Growl or notify-send).
   notify_on_compilation_success: true
   notify_on_compilation_failure: true
+
+deploy:
+  res0l:
+    kind: rsync
+    dst:  "openra@openra.res0l.net:/home/openra/openra.res0l.net"


### PR DESCRIPTION
http://nanoc.ws/docs/guides/deploying-nanoc-sites/

`nanoc deploy --target res0l` will work for everyone with SSH access which currently excludes the Travis workers, but it is a start.
