### PR TITLE
Removed openra.ipdx.ru

### DIFF
--- a/content/packages/cnc-mirrors.txt
+++ b/content/packages/cnc-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.ppmsite.com/cnc-packages.zip
-http://openra.ipdx.ru/packages/cnc-packages.zip
 http://openra.dxnet.ru/cnc-packages.zip

--- a/content/packages/d2k-103-mirrors.txt
+++ b/content/packages/d2k-103-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.ppmsite.com/d2k-103-packages.zip
-http://openra.ipdx.ru/packages/d2k-103-packages.zip
 http://openra.dxnet.ru/d2k-103-packages.zip

--- a/content/packages/d2k-mirrors.txt
+++ b/content/packages/d2k-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.ppmsite.com/d2k-packages.zip
-http://openra.ipdx.ru/packages/d2k-packages.zip
 http://openra.dxnet.ru/d2k-packages.zip

--- a/content/packages/ra-mirrors.txt
+++ b/content/packages/ra-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.ppmsite.com/ra-packages.zip
-http://openra.ipdx.ru/packages/ra-packages.zip
 http://openra.dxnet.ru/ra-packages.zip

--- a/content/packages/ts-mirrors.txt
+++ b/content/packages/ts-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.dxnet.ru/ts-packages.zip
 http://openra.ppmsite.com/ts-packages.zip
-http://openra.ipdx.ru/packages/ts-packages.zip

--- a/content/releases/windows/cg-mirrors.txt
+++ b/content/releases/windows/cg-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.ppmsite.com/cg-win32.zip
-http://openra.ipdx.ru/packages/cg-win32.zip
 http://openra.dxnet.ru/cg-win32.zip

--- a/content/releases/windows/freetype-mirrors.txt
+++ b/content/releases/windows/freetype-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.ppmsite.com/freetype-zlib.zip
-http://openra.ipdx.ru/packages/freetype-zlib.zip
 http://openra.dxnet.ru/freetype-zlib.zip

--- a/content/releases/windows/openal-mirrors.txt
+++ b/content/releases/windows/openal-mirrors.txt
@@ -1,3 +1,2 @@
 http://openra.ppmsite.com/oalinst.zip
-http://openra.ipdx.ru/packages/oalinst.zip
 http://openra.dxnet.ru/oalinst.zip

--- a/content/releases/windows/sdl-mirrors.txt
+++ b/content/releases/windows/sdl-mirrors.txt
@@ -1,3 +1,2 @@
-http://openra.ipdx.ru/packages/SDL-1.2.14-win32.zip
 http://openra.ppmsite.com/SDL-1.2.14-win32.zip
 http://openra.dxnet.ru/SDL-1.2.14-win32.zip


### PR DESCRIPTION
Webserver at http://openra.ipdx.ru is gone and we can't reach @xaionaro. His other server is still there and now 50% of the mirror network.
