### PR TITLE
Added rough mirror checking into get-dependency.php

### DIFF
--- a/content/get-dependency.php
+++ b/content/get-dependency.php
@@ -3,8 +3,9 @@
 // === configuration ===
 
 // Minimal interval between mail notifies about mirrors problems
-
 define('NOTIFY_MININTERVAL',		1800 /* 30 min */);
+
+// Minimal interval between mirror check
 define('MIRRORCHECK_MININTERVAL',	 600 /* 10 min */);
 
 // === program ===


### PR DESCRIPTION
Added rough mirror checking into get-dependency.php with using of

```
$success = @file_get_contents($mirror, false, $ctx_goodhttp, -1, 1) !== FALSE;
```

If we can successfully read one byte of the desired file, mirror is considered to be "good".

Related: #78, #80, #77, #66, #13.
