### PR TITLE
Added missing 404 title

### DIFF
--- a/content/404.yaml
+++ b/content/404.yaml
@@ -1,0 +1,3 @@
+---
+title: "Page not found"
+---


### PR DESCRIPTION
Fixes `Title: OpenRA -` for http://openra.res0l.net/404/
