### PR TITLE
Use GitHub Releases

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -64,7 +64,7 @@ $(document).ready(function(){
   <h3>Download OpenRA <%= "for " unless platform == "source" %> <%= PLATFORM_NAME[platform] %></h3>
   <p class="downloadblurb"><%= PLATFORM_BLURB[platform] %></p>
   <ul class="downloadlinks">
-    <li><a href="<%= package_url(platform, RELEASE_TAG) %>" title="Download <%= RELEASE_TAG %>">Download <%= RELEASE_TAG %><br />(<%= package_size(platform, RELEASE_TAG) %>)</a></li>
+    <li><a href="<%= mirrored_package_url(platform, RELEASE_TAG) %>" title="Download <%= RELEASE_TAG %>">Download <%= RELEASE_TAG %><br />(<%= package_size(platform, RELEASE_TAG) %>)</a></li>
     <li><a href="<%= package_url(platform, PLAYTEST_TAG) %>" title="Download <%= PLAYTEST_TAG %>">Download <%= PLAYTEST_TAG %><br />(<%= package_size(platform, PLAYTEST_TAG) %>)</a></li>
   </ul>
   <p>Older releases can be found in our <a href="<%= DOWNLOAD_BASE_PATH + package_path(platform) %>">package archive</a>.</p>

--- a/lib/openra.rb
+++ b/lib/openra.rb
@@ -1,4 +1,6 @@
 DOWNLOAD_BASE_PATH = "http://openra.res0l.net/assets/downloads/"
+DOWNLOAD_GITHUB_RELEASE_PATH = "https://github.com/OpenRA/OpenRA/releases/download/"
+DOWNLOAD_GITHUB_SOURCE_PATH = "https://github.com/OpenRA/OpenRA/archive/"
 
 PLAYTEST_TAG = "playtest-20131220"
 RELEASE_TAG = "release-20131223"
@@ -70,6 +72,15 @@ end
 
 def package_url(platform, tag)
     DOWNLOAD_BASE_PATH + package_path(platform) + package_name(platform, tag)
+end
+
+def mirrored_package_url(platform, tag)
+    case platform 
+        when "source"
+            DOWNLOAD_GITHUB_SOURCE_PATH + package_name(platform, tag)
+        else
+            DOWNLOAD_GITHUB_RELEASE_PATH + tag + '/' + package_name(platform, tag)
+    end
 end
 
 def package_path(platform)


### PR DESCRIPTION
as discussed in OpenRA/OpenRA#3764 an alternative to https://github.com/OpenRA/OpenRAWeb/pull/93. During the live stream that made us popular over night, people had very slow downloads, see http://www.reddit.com/r/Cynicalbrit/comments/1wwhnb/command_conquer_red_alert_because_why_not/cf67jda for example.
