### PR TITLE
Decreased JavaScript loading times

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -13,7 +13,7 @@
     <link href="/news/atom/" rel="alternate" type="application/atom+xml">
   <script>
   function supportsSVG() {
-    return !!document.createElementNS && !!document.createElementNS('http://www.w3.org/2000/svg','svg').createSVGRect;  
+    return !!document.createElementNS && !!document.createElementNS('http://www.w3.org/2000/svg','svg').createSVGRect;
   }
   $(document).ready(function(){
     if (!supportsSVG()) {


### PR DESCRIPTION
I somehow failed to integrate http://tablesorter.com into the http://open-ra.org/games sub-page (probably does not work with dynamically generated tables) and kept the .min.js
