### PR TITLE
Add mirrors in China

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /output
 /tmp
+
+*.swp

--- a/content/packages/cnc-mirrors.txt
+++ b/content/packages/cnc-mirrors.txt
@@ -4,11 +4,12 @@ http://nazgul.dxnet.ru/cnc-packages.zip
 http://srvdonate.ut.mephi.ru/openra/cnc-packages.zip
 http://openra-mirror.ihptru.net/cnc-packages.zip
 http://ra.norimg.no/openra/cnc-packages.zip
-http://mirror.anthonos.org/openra/cnc-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/cnc-packages.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/cnc-packages.zip
 http://mirrors.ustc.edu.cn/anthon/openra/cnc-packages.zip
 http://mirrors.yun-idc.com/anthon/openra/cnc-packages.zip
 http://mirrors.oss.org.cn/anthon/openra/cnc-packages.zip
 http://mirror.pcbeta.com/anthonos/openra/cnc-packages.zip
-http://mirrors.oss.org.cn/anthon/openra/cnc-packages.zip
 http://mirrors.scie.in/anthon/openra/cnc-packages.zip
 http://mirrors.hust.edu.cn/anthon/openra/cnc-packages.zip
+

--- a/content/packages/d2k-103-mirrors.txt
+++ b/content/packages/d2k-103-mirrors.txt
@@ -4,11 +4,11 @@ http://nazgul.dxnet.ru/d2k-103-packages.zip
 http://srvdonate.ut.mephi.ru/openra/d2k-103-packages.zip
 http://openra-mirror.ihptru.net/d2k-103-packages.zip
 http://ra.norimg.no/openra/d2k-103-packages.zip
-http://mirror.anthonos.org/openra/d2k-103-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/d2k-103-packages.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/d2k-103-packages.zip
 http://mirrors.ustc.edu.cn/anthon/openra/d2k-103-packages.zip
 http://mirrors.yun-idc.com/anthon/openra/d2k-103-packages.zip
 http://mirrors.oss.org.cn/anthon/openra/d2k-103-packages.zip
 http://mirror.pcbeta.com/anthonos/openra/d2k-103-packages.zip
-http://mirrors.oss.org.cn/anthon/openra/d2k-103-packages.zip
 http://mirrors.scie.in/anthon/openra/d2k-103-packages.zip
 http://mirrors.hust.edu.cn/anthon/openra/d2k-103-packages.zip

--- a/content/packages/d2k-complete-mirrors.txt
+++ b/content/packages/d2k-complete-mirrors.txt
@@ -1,1 +1,9 @@
 http://openra.ppmsite.com/d2k-complete-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/d2k-complete-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/d2k-complete-packages.zip
+http://mirrors.ustc.edu.cn/anthon/openra/d2k-complete-packages.zip
+http://mirrors.yun-idc.com/anthon/openra/d2k-complete-packages.zip
+http://mirrors.oss.org.cn/anthon/openra/d2k-complete-packages.zip
+http://mirrors.hust.edu.cn/anthon/openra/d2k-complete-packages.zip
+http://mirror.pcbeta.com/anthonos/openra/d2k-complete-packages.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/d2k-complete-packages.zip

--- a/content/packages/d2k-mirrors.txt
+++ b/content/packages/d2k-mirrors.txt
@@ -4,3 +4,11 @@ http://nazgul.dxnet.ru/d2k-packages.zip
 http://srvdonate.ut.mephi.ru/openra/d2k-packages.zip
 http://openra-mirror.ihptru.net/d2k-packages.zip
 http://ra.norimg.no/openra/d2k-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/d2k-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/d2k-packages.zip
+http://mirrors.ustc.edu.cn/anthon/openra/d2k-packages.zip
+http://mirrors.yun-idc.com/anthon/openra/d2k-packages.zip
+http://mirrors.oss.org.cn/anthon/openra/d2k-packages.zip
+http://mirrors.hust.edu.cn/anthon/openra/d2k-packages.zip
+http://mirror.pcbeta.com/anthonos/openra/d2k-packages.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/d2k-packages.zip

--- a/content/packages/ra-mirrors.txt
+++ b/content/packages/ra-mirrors.txt
@@ -4,11 +4,13 @@ http://nazgul.dxnet.ru/ra-packages.zip
 http://srvdonate.ut.mephi.ru/openra/ra-packages.zip
 http://openra-mirror.ihptru.net/ra-packages.zip
 http://ra.norimg.no/openra/ra-packages.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/ra-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/ra-packages.zip
 http://mirror.anthonos.org/openra/ra-packages.zip
 http://mirrors.ustc.edu.cn/anthon/openra/ra-packages.zip
 http://mirrors.yun-idc.com/anthon/openra/ra-packages.zip
 http://mirrors.oss.org.cn/anthon/openra/ra-packages.zip
 http://mirror.pcbeta.com/anthonos/openra/ra-packages.zip
-http://mirrors.oss.org.cn/anthon/openra/ra-packages.zip
 http://mirrors.scie.in/anthon/openra/ra-packages.zip
 http://mirrors.hust.edu.cn/anthon/openra/ra-packages.zip
+

--- a/content/packages/ts-mirrors.txt
+++ b/content/packages/ts-mirrors.txt
@@ -4,3 +4,11 @@ http://nazgul.dxnet.ru/ts-packages.zip
 http://srvdonate.ut.mephi.ru/openra/ts-packages.zip
 http://openra-mirror.ihptru.net/ts-packages.zip
 http://ra.norimg.no/openra/ts-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/ts-packages.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/ts-packages.zip
+http://mirrors.ustc.edu.cn/anthon/openra/ts-packages.zip
+http://mirrors.yun-idc.com/anthon/openra/ts-packages.zip
+http://mirrors.oss.org.cn/anthon/openra/ts-packages.zip
+http://mirrors.hust.edu.cn/anthon/openra/ts-packages.zip
+http://mirror.pcbeta.com/anthonos/openra/ts-packages.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/ts-packages.zip

--- a/content/releases/windows/cg-mirrors.txt
+++ b/content/releases/windows/cg-mirrors.txt
@@ -5,3 +5,11 @@ http://srvdonate.ut.mephi.ru/openra/cg-win32.zip
 http://openra-mirror.ihptru.net/cg-win32.zip
 http://ftp.ubuntu-tw.org/mirror/anthonos/openra/cg-win32.zip
 http://mirror.oss.maxcdn.com/anthonos/cg-win32.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/cg-win32.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/cg-win32.zip
+http://mirrors.ustc.edu.cn/anthon/openra/cg-win32.zip
+http://mirrors.yun-idc.com/anthon/openra/cg-win32.zip
+http://mirrors.oss.org.cn/anthon/openra/cg-win32.zip
+http://mirrors.hust.edu.cn/anthon/openra/cg-win32.zip
+http://mirror.pcbeta.com/anthonos/openra/cg-win32.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/cg-win32.zip

--- a/content/releases/windows/freetype-mirrors.txt
+++ b/content/releases/windows/freetype-mirrors.txt
@@ -3,3 +3,11 @@ http://openra.dxnet.ru/freetype-zlib.zip
 http://nazgul.dxnet.ru/freetype-zlib.zip
 http://srvdonate.ut.mephi.ru/openra/freetype-zlib.zip
 http://openra-mirror.ihptru.net/freetype-zlib.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/freetype-zlib.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/freetype-zlib.zip
+http://mirrors.ustc.edu.cn/anthon/openra/freetype-zlib.zip
+http://mirrors.yun-idc.com/anthon/openra/freetype-zlib.zip
+http://mirrors.oss.org.cn/anthon/openra/freetype-zlib.zip
+http://mirrors.hust.edu.cn/anthon/openra/freetype-zlib.zip
+http://mirror.pcbeta.com/anthonos/openra/freetype-zlib.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/freetype-zlib.zip

--- a/content/releases/windows/openal-mirrors.txt
+++ b/content/releases/windows/openal-mirrors.txt
@@ -3,3 +3,11 @@ http://openra.dxnet.ru/oalinst.zip
 http://nazgul.dxnet.ru/oalinst.zip
 http://srvdonate.ut.mephi.ru/openra/oalinst.zip
 http://openra-mirror.ihptru.net/oalinst.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/oalinst.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/oalinst.zip
+http://mirrors.ustc.edu.cn/anthon/openra/oalinst.zip
+http://mirrors.yun-idc.com/anthon/openra/oalinst.zip
+http://mirrors.oss.org.cn/anthon/openra/oalinst.zip
+http://mirrors.hust.edu.cn/anthon/openra/oalinst.zip
+http://mirror.pcbeta.com/anthonos/openra/oalinst.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/oalinst.zip

--- a/content/releases/windows/sdl-mirrors.txt
+++ b/content/releases/windows/sdl-mirrors.txt
@@ -3,3 +3,11 @@ http://openra.dxnet.ru/SDL-1.2.14-win32.zip
 http://nazgul.dxnet.ru/SDL-1.2.14-win32.zip
 http://srvdonate.ut.mephi.ru/openra/SDL-1.2.14-win32.zip
 http://openra-mirror.ihptru.net/SDL-1.2.14-win32.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/SDL-1.2.14-win32.zip
+http://ftp.ubuntu-tw.org/mirror/anthonos/openra/SDL-1.2.14-win32.zip
+http://mirrors.ustc.edu.cn/anthon/openra/SDL-1.2.14-win32.zip
+http://mirrors.yun-idc.com/anthon/openra/SDL-1.2.14-win32.zip
+http://mirrors.oss.org.cn/anthon/openra/SDL-1.2.14-win32.zip
+http://mirrors.hust.edu.cn/anthon/openra/SDL-1.2.14-win32.zip
+http://mirror.pcbeta.com/anthonos/openra/SDL-1.2.14-win32.zip
+http://mirror.oss.maxcdn.com/anthonos/openra/SDL-1.2.14-win32.zip


### PR DESCRIPTION
Well, at first I just wanted to create a mirror on mirror.anthonos.org , since this Linux distro has added OpenRA into its deb repo and resource package downloading issues often occur in China (behind the GFW ). 

And then I found that the rsync of these extra mirrors synced everything from the AnthonOS mirror ... That's why there are so many other mirrors now.

Mirrors http://mirrors.scie.in/anthon/ and http://mirrors.hust.edu.cn/anthon/ seems to be delaying a bit so files from these mirrors are still 404s now.

Mirror syncing status can be viewed HERE http://anthon.dormforce.net/status/. 
