### PR TITLE
Changed 404 page name to retain GitHub pages compatibility

### DIFF
--- a/Rules
+++ b/Rules
@@ -59,6 +59,9 @@ compile '*' do
   end
 end
 
+route '/404/' do
+  '/404.html'
+end
 
 route '/htaccess/' do
   '/.htaccess'

--- a/content/htaccess.txt
+++ b/content/htaccess.txt
@@ -1,5 +1,5 @@
 # Custom file not found sub-page
-ErrorDocument 404 /404/
+ErrorDocument 404 /404.html
 
 # Format the /assets/downloads/ folders properly
 IndexOptions FancyIndexing VersionSort XHTML NameWidth=* SuppressDescription


### PR DESCRIPTION
Already deployed at https://github.com/OpenRA/openra.github.io/blob/master/404.html See https://help.github.com/articles/custom-404-pages
