### PR TITLE
Added a line to mention the July playtest RC 2 on the frontpage

### DIFF
--- a/content/news/playtest-20140709.md
+++ b/content/news/playtest-20140709.md
@@ -1,3 +1,5 @@
+**Update: We have released a second release candidate (20140711) which fixes a few additional issues. Thanks to everyone who reported problems and submitted patches.**
+
 We have just released our first July release candidate, [playtest-20140709](/download/).
 
 This short development cycle has been extremely productive, and includes some long-awaited features:


### PR DESCRIPTION
followup of https://github.com/OpenRA/OpenRAWeb/pull/146.
