### PR TITLE
Fixed invalid 'og:type' of 'video.game'

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=1024" />
     <meta name="description" content="Open Source reimplementation of Westwood Studios' 2D Command and Conquer games" />
     <meta property="og:title" content="OpenRA" />
-    <meta property="og:type" content="video.game" />
+    <meta property="og:type" content="website" />
     <meta property="og:url" content="http://www.openra.net/" />
     <meta property="og:image" content="http://www.openra.net/images/soviet-logo-fallback.png" />
     <title>OpenRA - <%= @item[:title] %></title>


### PR DESCRIPTION
as reported by https://developers.facebook.com/tools/debug/og/object/. This is a followup of https://github.com/OpenRA/OpenRAWeb/pull/157.
