### PR TITLE
Added a link to resource.openra.net

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -17,6 +17,6 @@
 <h3>Getting Involved</h3>
 <div class="communityblock">
 <img src="/images/development.svg" alt="Development" title="Development" />
-<p>We are a small team, so anything you can do to help is greatly appreciated.<br />This could be as simple as filing bug reports or telling your friends about OpenRA, creating maps and mods, through to helping improve the game engine.</p>
-<p>See the <a href="http://wiki.openra.net/#development-topics" alt="development topics">development topics</a> on our wiki for more information.</p>
+<p>We are a small team, so anything you can do to help is greatly appreciated.<br /> See the <a href="http://wiki.openra.net/#development-topics" alt="development topics">development topics</a> on our wiki for more information.</p>
+<p>You can share custom content such as maps on the <a href="http://resource.openra.net/">OpenRA Resource Center</a> site.</p>
 </div>


### PR DESCRIPTION
as described in #108 it was not directly linked from the main website. The bug reporting was redundant to the help section and the tell your friends was redundant to the get in touch via social networks.
