### PR TITLE
Tweaked the openSUSE build service links

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -118,24 +118,15 @@ $(document).ready(function(){
 <div id="fedora" class="tab">
   <hr />
   <h3>Install OpenRA for Fedora</h3>
-  <p>Stable releases are available via our <a href="https://build.opensuse.org/package/binaries/games:openra/release?repository=Fedora_19">openSUSE Build Service repository</a>.<br />You can add the repository from the terminal:</p>
-  <pre>
-# cd /etc/yum.repos.d/
-# wget http://download.opensuse.org/repositories/games:/openra/Fedora_19/games:openra.repo</pre>
-  <p>The stable release can then be installed by running:</p>
-  <pre># yum install openra</pre>
+  <p>Stable releases and playtests are available via our <a href="http://software.opensuse.org/download.html?project=games:openra&amp;package=openra">openSUSE Build Service repository</a>.</p>
   <p>OpenRA is also available on <a href="http://www.desura.com/games/openra">Desura</a> and <a href="https://lutris.net/games/openra/">Lutris</a>.</p>
   <p class="downloadthirdparty">We do not directly maintain these external package sources, so there may be delays when a new version is released.<br />Please contact the downstream repository maintainers about any packaging issues.</p>
 </div>
 <div id="opensuse" class="tab">
   <hr />
   <h3>Install OpenRA for openSUSE</h3>
-  <p>Stable releases are available in the <a href="http://software.opensuse.org/download.html?project=games&package=openra">openSUSE games repository</a>.</p>
-  <br />
-  <ul class="downloadlinks">
-    <li><a href="http://software.opensuse.org/download.html?project=games&package=openra" title="Download from software.opensuse.org">Download OpenRA from<br />software.opensuse.org</a></li>
-  </ul>
-  <br />
+  <p>Stable releases are available in the <a href="http://software.opensuse.org/download.html?project=games&amp;package=openra">openSUSE games repository</a>.</p>
+  <p>Playtests are available via our <a href="http://software.opensuse.org/download.html?project=games:openra&amp;package=openra">openSUSE Build Service repository</a>.</p>
   <p>OpenRA is also available on <a href="http://www.desura.com/games/openra">Desura</a> and <a href="https://lutris.net/games/openra/">Lutris</a>.</p>
   <p class="downloadthirdparty">We do not directly maintain these external package sources, so there may be delays when a new version is released.<br />Please contact the downstream repository maintainers about any packaging issues.</p>
 </div>


### PR DESCRIPTION
~~This adds links to the openSUSE wiki with further information~~
- ~~https://en.opensuse.org/OpenRA~~
- ~~https://en.opensuse.org/Games~~

and avoids linking the download page twice. Also it may be confusing that you don't get a package, but another HTML site with instructions. I tried to mitigate that by renaming the button a bit.
