### PR TITLE
Move decryption of ssh key from script to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
  - nanoc compile
 
 after_success:
- - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && ./update-github-pages.sh
+ - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && openssl aes-256-cbc -k $KEY -in $TRAVIS_BUILD_DIR/ssh.enc -d -out $TRAVIS_BUILD_DIR/id_rsa && ./update-github-pages.sh
 
 # Only watch the production branch.
 branches:

--- a/update-github-pages.sh
+++ b/update-github-pages.sh
@@ -7,8 +7,7 @@ git config --global user.email "orabot@users.noreply.github.com"
 cd "$HOME"
 
 mkdir -p "$HOME"/.ssh
-[[ -n "$KEY" ]] && echo "decryption key is set"
-openssl aes-256-cbc -k $KEY -in "$TRAVIS_BUILD_DIR"/ssh.enc -d -out "$HOME"/.ssh/id_rsa
+cp "$TRAVIS_BUILD_DIR"/id_rsa "$HOME"/.ssh
 
 git clone --branch=master git@github.com:OpenRA/openra.github.io.git openra.net > /dev/null
 cd openra.net


### PR DESCRIPTION
The encrypted "$KEY" env var apparently isn't set during the runtime of the update script (the debug statement wasn't shown in https://travis-ci.org/OpenRA/OpenRAWeb/builds/47424788#L296), so try decrypting directly in .travis.yml.