### PR TITLE
Disable deployment to gh-pages by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 
 env:
   global:
-    secure: "g0ObdYxcbfkLzSNmyhYN+74qHsGEg3mwt9e0tZLnmCwISL8qSErjHz+t46Jdyw4hXrQ63kXnCQApIqbtiPywXyKgMzINhXTnzuYbXc4wfrSz900xBw/eCKTICJO+DcwHgwE/RUbQzAB0a/lc6Y49YTr7ez9i2Uv1ecQ/Wo0Mcpo="
 
 install:
  - gem install builder kramdown octokit uglifier
@@ -15,7 +14,7 @@ script:
  - nanoc compile
 
 after_success:
- - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && openssl aes-256-cbc -k $KEY -in $TRAVIS_BUILD_DIR/ssh.enc -d -out $TRAVIS_BUILD_DIR/id_rsa && ./update-github-pages.sh
+# - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && ./update-github-pages.sh
 
 # Only watch the production branch.
 branches:

--- a/update-github-pages.sh
+++ b/update-github-pages.sh
@@ -7,7 +7,7 @@ git config --global user.email "orabot@users.noreply.github.com"
 cd "$HOME"
 
 mkdir -p "$HOME"/.ssh
-cp "$TRAVIS_BUILD_DIR"/id_rsa "$HOME"/.ssh
+openssl aes-256-cbc -k $KEY -in "$TRAVIS_BUILD_DIR"/ssh.enc -d -out "$HOME"/.ssh/id_rsa
 
 git clone --branch=master git@github.com:OpenRA/openra.github.io.git openra.net > /dev/null
 cd openra.net


### PR DESCRIPTION
I kept the ssh key and the original encryption key with which the copy in the repo was encrypted around. If anyone can get the secure env vars feature on Travis working properly, then the deployment should also start working.
