### PR TITLE
Adjust the news a bit regarding Linux packaging

### DIFF
--- a/content/news/playtest-20150118.md
+++ b/content/news/playtest-20150118.md
@@ -19,7 +19,7 @@ See the [changelog](http://changelog.openra.net) for more details on the playtes
 
 The playtest-20150118 build is available from the [download](/download/) page.
 
-We have put a lot of work into streamlining our development and release process, which included a shake-up of our Linux packages.  We now provide distro-specific RPM and Arch Linux packages via the [openSUSE Build Service](https://software.opensuse.org/download.html?project=games:openra&package=openra), and recommend that most users install OpenRA from their main distribution repositories.  We have also fixed the "bad quality" package warning that occurs when installing our Ubuntu package.
+We have put a lot of work into streamlining our development and release process, which included a shake-up of our Linux packages.  We now provide distro-specific RPM via the [openSUSE Build Service](https://software.opensuse.org/download.html?project=games:openra&package=openra), but recommend that most users install OpenRA from their main distribution repositories.  We have also fixed the "bad quality" package warning that occurs when installing our Ubuntu package.
 
 <div style="text-align:center" markdown="1">
 ![Countries](/images/news/20150118-ra-countries-dropdown.png)

--- a/content/news/playtest-20150118.md
+++ b/content/news/playtest-20150118.md
@@ -32,7 +32,7 @@ We overhauled the server browser. It is grouped by mods with the currently loade
 
 ![Sandworms and Carryalls](/images/news/20150118-d2k-sandworm-carryall.png)
 
-Carryalls that automatically transport harvesters across longer distances. Also sandworms are now included in our D2K mod. The balancing is a work in progress and they can be disabled in the lobby options.
+Let your slow harvesters make use of the convenient airlift shuttle service, and save your units from becoming worm food! Carryalls and Sandworms are now included in our D2K mod. The worm balancing is a work in progress, and they can be disabled in the lobby options.
 
 ![Heightmaps](/images/news/20150118-ts-heightmaps.png)
 


### PR DESCRIPTION
https://build.opensuse.org/package/show/games:openra/playtest The situation is looking pretty grim to be honest. This playtest does not compile on Fedora 21, because it comes with ancient Mono 2.10 which seems to have some bugs we no longer workaround. There is also an openBuildService limitation for Debian packages which does not allow two tarballs so I can't add the missing thirdparty folder. Not sure why the Arch Linux package is broken, but I guess no one uses it anyway as it is already packaged in AUR. I think about just dropping it.