### PR TITLE
Changed the graph colors to be easier for the eyes

### DIFF
--- a/content/games.html
+++ b/content/games.html
@@ -128,8 +128,8 @@
     };
 
     var ds_graph_options = {
-      'playing': { label: 'Playing', color: "#0A0", lines: { show: true, fill: 0.7, lineWidth: 0 } },
-      'waiting': { label: 'Waiting', color: "#F80", lines: { show: true, fill: 0.7, lineWidth: 0 } }
+      'playing': { label: 'Playing', color: "#6a1200", lines: { show: true, fill: 0.7, lineWidth: 0 } },
+      'waiting': { label: 'Waiting', color: "#d62700", lines: { show: true, fill: 0.7, lineWidth: 0 } }
     };
 
     var rrdflot_options = {
@@ -172,7 +172,7 @@
 </table>
 <br/>
 <h3>Player Activity</h3>
-<p>View the numbers of gamers <span class="gamePlaying">playing</span> and <span class="gameWaiting">waiting</span> over the last fortnight:</p>
+<p>View the numbers of gamers <span class="statsPlaying">playing</span> and <span class="statsWaiting">waiting</span> over the last fortnight:</p>
 <a href="/players/"><div id="players"><center><h4>Loading...</h4></center></div></a>
 <p>More detailed graphs are available at the <a href="/players/">player statistics</a> page.</p>
 </div>

--- a/content/players.html
+++ b/content/players.html
@@ -24,8 +24,8 @@
     fivemin_options.tooltipOpts.content = "%s: %y at %x";
 
     var ds_graph_options = {
-      'playing': { label: 'Playing', color: "#0A0", lines: { show: true, fill: 0.7, lineWidth: 0 } },
-      'waiting': { label: 'Waiting', color: "#F80", lines: { show: true, fill: 0.7, lineWidth: 0 } }
+      'playing': { label: 'Playing', color: "#6a1200", lines: { show: true, fill: 0.7, lineWidth: 0 } },
+      'waiting': { label: 'Waiting', color: "#d62700", lines: { show: true, fill: 0.7, lineWidth: 0 } }
     };
 
     var rrdflot_daily = {
@@ -93,7 +93,7 @@
 </script>
 
 <h3>Player Statistics</h3>
-
+<p>View the numbers of gamers <span class="statsPlaying">playing</span> and <span class="statsWaiting">waiting</span> over a period of time.
 <noscript><div class="noscript">Please enable JavaScript to view the player statistics.</div></noscript>
 <div id="servercontainer" style="display: none">
 <div id="thirtyseconds"><center><h4>Loading...</h4></center></div>

--- a/content/style.css
+++ b/content/style.css
@@ -242,11 +242,11 @@ td, th, tr {
   font-size:10px;
 }
 
-.gameWaiting {
+#serverlist .gameWaiting {
   color: #F80;
 }
 
-.gamePlaying {
+#serverlist .gamePlaying {
   color: #0A0;
 }
 
@@ -389,4 +389,12 @@ pre {
   -moz-border-radius: 10px;
   -webkit-border-radius: 10px;
   -khtml-border-radius: 10px;
+}
+
+.statsWaiting {
+  color: #d62700;
+}
+
+.statsPlaying {
+  color: #6a1200;
 }

--- a/content/style.css
+++ b/content/style.css
@@ -243,11 +243,11 @@ td, th, tr {
 }
 
 #serverlist .gameWaiting {
-  color: #F80;
+  color: #0A0;
 }
 
 #serverlist .gamePlaying {
-  color: #0A0;
+  color: #F80;
 }
 
 #serverlist .greyout {


### PR DESCRIPTION
The extensive bike-shedding at https://github.com/OpenRA/OpenRAWeb/pull/176 butchered my whole design. The stacked and color-filled graphs look horrible with orange and green so I go with @pchote's and @xaionaro's original red design: see https://github.com/OpenRA/OpenRAWeb/pull/176#issuecomment-64949667 and http://openra.ipdx.ru/graphs.html

This also reverts https://github.com/OpenRA/OpenRAWeb/pull/192 which actually swapped the colors doing it exactly the other way round compared to the in-game client which does not clarify anything.