### PR TITLE
Changed the wording on the frontpage introduction

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -20,7 +20,7 @@
 <div>
   <h2>Welcome Back, Commander</h2>
   <p>OpenRA is a Libre/Free Real Time Strategy engine project that revives the classic Command&nbsp;&amp;&nbsp;Conquer titles.</p>
-  <p>We include reimaginations of C&amp;C&nbsp;(Tiberian&nbsp;Dawn), C&amp;C:&nbsp;Red&nbsp;Alert, and Dune&nbsp;2000. These are not intended to be perfect copies, but instead combine the classic gameplay of the originals with modern improvements such as unit veterancy and the fog of war.</p>
+  <p>We include reimaginations of C&amp;C&nbsp;(Tiberian&nbsp;Dawn), C&amp;C:&nbsp;Red&nbsp;Alert, and Dune&nbsp;2000. These are not intended to be perfect copies, but instead combine the gameplay of the originals with modern improvements such as unit veterancy and the fog of war.</p>
   <p>OpenRA's primary focus is cross-platform multiplayer between Windows, OS&nbsp;X, and Linux; however, we include a number of single-player missions, and also support skirmish games against AI bots.</p>
 </div>
 

--- a/content/index.html
+++ b/content/index.html
@@ -20,7 +20,7 @@
 <div>
   <h2>Welcome Back, Commander</h2>
   <p>OpenRA is a Libre/Free Real Time Strategy engine project that revives the classic Command&nbsp;&amp;&nbsp;Conquer titles.</p>
-  <p>We include reimaginations of C&amp;C&nbsp;(Tiberian&nbsp;Dawn), C&amp;C:&nbsp;Red&nbsp;Alert, and Dune&nbsp;2000. These are not intended to be perfect copies, but instead combine the gameplay of the originals with modern improvements such as unit veterancy and the fog of war.</p>
+  <p>It includes reimaginations of C&amp;C&nbsp;(Tiberian&nbsp;Dawn), C&amp;C:&nbsp;Red&nbsp;Alert, and Dune&nbsp;2000. These are not intended to be perfect copies, but instead combine the gameplay of the originals with modern improvements such as unit veterancy and the fog of war.</p>
   <p>OpenRA's primary focus is cross-platform multiplayer between Windows, OS&nbsp;X, and Linux; however, we include a number of single-player missions, and also support skirmish games against AI bots.</p>
 </div>
 

--- a/content/index.html
+++ b/content/index.html
@@ -19,8 +19,8 @@
 </div>
 <div>
   <h2>Welcome Back, Commander</h2>
-  <p>OpenRA is a Libre/Free Real Time Strategy project that recreates the classic Command&nbsp;&amp;&nbsp;Conquer titles.</p>
-  <p>We include recreations of C&amp;C&nbsp;(Tiberian&nbsp;Dawn), C&amp;C:&nbsp;Red&nbsp;Alert, and Dune&nbsp;2000. These are not intended to be perfect copies, but instead combine the classic gameplay of the originals with modern improvements such as unit veterancy and the fog of war.</p>
+  <p>OpenRA is a Libre/Free Real Time Strategy engine project that revives the classic Command&nbsp;&amp;&nbsp;Conquer titles.</p>
+  <p>We include reimaginations of C&amp;C&nbsp;(Tiberian&nbsp;Dawn), C&amp;C:&nbsp;Red&nbsp;Alert, and Dune&nbsp;2000. These are not intended to be perfect copies, but instead combine the classic gameplay of the originals with modern improvements such as unit veterancy and the fog of war.</p>
   <p>OpenRA's primary focus is cross-platform multiplayer between Windows, OS&nbsp;X, and Linux; however, we include a number of single-player missions, and also support skirmish games against AI bots.</p>
 </div>
 


### PR DESCRIPTION
One of the main points of criticism that is repeated endlessly on forum posts like http://cnc-comm.com/community/index.php?topic=3368.0 where people speak disparagingly about OpenRA is that the term "recreation" is misleading, because we go further than that: http://wiki.openra.net/FAQ#this-is-not-true-to-the-original