### PR TITLE
Fix version of gem depedency execjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ env:
     secure: "Ot/NHtOO6W2pGcWAvXpdz3tKoppcvyZ3XlbPNMr/qOlRhcySMPB5wgkdZJFS3D+E5QoXeB+aOYuAW4dqm5R2bnwCoAnbgMrLItN6nejQ/CR5gejEHLrugoM5hXp0BuY/MUiRMkhj9ERMDIbwUulC2Zpsmx05Wq4q7+ZRBF451rE="
 
 install:
- - gem install builder kramdown octokit uglifier
+ - gem install builder kramdown octokit
+ - gem install execjs --version 2.5.0
+ - gem install uglifier
  - gem install nanoc --version 3.6.9
 
 script:


### PR DESCRIPTION
A new version of execjs was released (2.5.1), which requires at least Ruby 2.0.0, which isn't available on Travis.  Adding a hard dependency on the specific version that works (2.5.0) instead.