### PR TITLE
Update Archlinux development version URL

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -125,7 +125,7 @@ $(document).ready(function(){
   <hr />
   <h3>Install OpenRA for Arch Linux</h3>
   <p>Stable releases are available in the <a href="https://www.archlinux.org/packages/community/any/openra/">official Arch repository</a>, and can be installed using <span style="font-family: monospace;">pacman</span>:<pre>$ pacman -S openra </pre></p>
-  <p>Playtests are available via the <a href="https://aur.archlinux.org/packages/openra-playtest/">AUR</a>, and can be installed using <span style="font-family: monospace;">yaourt</span>:<pre>$ yaourt openra-playtest</pre></p>
+  <p>Development versions are available via the <a href="https://aur.archlinux.org/packages/openra-bleed/">AUR</a>, and can be installed using <span style="font-family: monospace;">yaourt</span>:<pre>$ yaourt openra-bleed</pre></p>
   <p>OpenRA is also available on <a href="http://www.desura.com/games/openra">Desura</a>.</p>
   <p class="downloadthirdparty">We do not directly maintain these external package sources, so there may be delays when a new version is released.<br />Please contact the downstream repository maintainers about any packaging issues.</p>
 </div>


### PR DESCRIPTION
The 'openra-playtest' has vanished from the AUR. The latest git version can be pulled from 'openra-bleed' instead.