### PR TITLE
Removed the AnthonOS mirrors as the packages are gone

### DIFF
--- a/content/packages/cnc-mirrors.txt
+++ b/content/packages/cnc-mirrors.txt
@@ -3,12 +3,6 @@ http://srvdonate.ut.mephi.ru/openra/cnc-packages.zip
 http://openra-mirror.ihptru.net/cnc-packages.zip
 http://openra.baxxster.no/openra/cnc-packages.zip
 http://openra.us.baxxster.no/openra/cnc-packages.zip
-http://repo.anthonos.org/openra/cnc-packages.zip
-http://ftp.nluug.nl/os/Linux/distr/anthon/openra/cnc-packages.zip
-http://ftp.tsukuba.wide.ad.jp/Linux/anthon/openra/cnc-packages.zip
-http://cdn.mirror.anthonos.org/openra/cnc-packages.zip
-http://mirrors.ustc.edu.cn/anthon/openra/cnc-packages.zip
-http://mirror.oss.maxcdn.com/anthonos/openra/cnc-packages.zip
 http://81.169.246.181/cnc-packages.zip
 http://zoners.eu/openra/cnc-packages.zip
 http://178.63.32.174/cnc-packages.zip

--- a/content/packages/cnc-music-mirrors.txt
+++ b/content/packages/cnc-music-mirrors.txt
@@ -3,12 +3,6 @@ http://srvdonate.ut.mephi.ru/openra/cnc-music.zip
 http://openra-mirror.ihptru.net/cnc-music.zip
 http://openra.baxxster.no/openra/cnc-music.zip
 http://openra.us.baxxster.no/openra/cnc-music.zip
-http://repo.anthonos.org/openra/cnc-music.zip
-http://ftp.nluug.nl/os/Linux/distr/anthon/openra/cnc-music.zip
-http://ftp.tsukuba.wide.ad.jp/Linux/anthon/openra/cnc-music.zip
-http://cdn.mirror.anthonos.org/openra/cnc-music.zip
-http://mirrors.ustc.edu.cn/anthon/openra/cnc-music.zip
-http://mirror.oss.maxcdn.com/anthonos/openra/cnc-music.zip
 http://81.169.246.181/cnc-music.zip
 http://zoners.eu/openra/cnc-music.zip
 http://178.63.32.174/cnc-music.zip

--- a/content/packages/d2k-103-mirrors.txt
+++ b/content/packages/d2k-103-mirrors.txt
@@ -3,12 +3,6 @@ http://srvdonate.ut.mephi.ru/openra/d2k-103-packages.zip
 http://openra-mirror.ihptru.net/d2k-103-packages.zip
 http://openra.baxxster.no/openra/d2k-103-packages.zip
 http://openra.us.baxxster.no/openra/d2k-103-packages.zip
-http://repo.anthonos.org/openra/d2k-103-packages.zip
-http://ftp.nluug.nl/os/Linux/distr/anthon/openra/d2k-103-packages.zip
-http://ftp.tsukuba.wide.ad.jp/Linux/anthon/openra/d2k-103-packages.zip
-http://cdn.mirror.anthonos.org/openra/d2k-103-packages.zip
-http://mirrors.ustc.edu.cn/anthon/openra/d2k-103-packages.zip
-http://mirror.oss.maxcdn.com/anthonos/openra/d2k-103-packages.zip
 http://81.169.246.181/d2k-103-packages.zip
 http://zoners.eu/openra/d2k-103-packages.zip
 http://178.63.32.174/d2k-103-packages.zip

--- a/content/packages/ra-mirrors.txt
+++ b/content/packages/ra-mirrors.txt
@@ -3,12 +3,6 @@ http://srvdonate.ut.mephi.ru/openra/ra-packages.zip
 http://openra-mirror.ihptru.net/ra-packages.zip
 http://openra.baxxster.no/openra/ra-packages.zip
 http://openra.us.baxxster.no/openra/ra-packages.zip
-http://repo.anthonos.org/openra/ra-packages.zip
-http://ftp.nluug.nl/os/Linux/distr/anthon/openra/ra-packages.zip
-http://ftp.tsukuba.wide.ad.jp/Linux/anthon/openra/ra-packages.zip
-http://cdn.mirror.anthonos.org/openra/ra-packages.zip
-http://mirrors.ustc.edu.cn/anthon/openra/ra-packages.zip
-http://mirror.oss.maxcdn.com/anthonos/openra/ra-packages.zip
 http://81.169.246.181/ra-packages.zip
 http://zoners.eu/openra/ra-packages.zip
 http://178.63.32.174/ra-music.zip

--- a/content/packages/ra-music-mirrors.txt
+++ b/content/packages/ra-music-mirrors.txt
@@ -3,11 +3,5 @@ http://srvdonate.ut.mephi.ru/openra/ra-music.zip
 http://openra-mirror.ihptru.net/ra-music.zip
 http://openra.baxxster.no/openra/ra-music.zip
 http://openra.us.baxxster.no/openra/ra-music.zip
-http://repo.anthonos.org/openra/ra-music.zip
-http://ftp.nluug.nl/os/Linux/distr/anthon/openra/ra-music.zip
-http://ftp.tsukuba.wide.ad.jp/Linux/anthon/openra/ra-music.zip
-http://cdn.mirror.anthonos.org/openra/ra-music.zip
-http://mirrors.ustc.edu.cn/anthon/openra/ra-music.zip
-http://mirror.oss.maxcdn.com/anthonos/openra/ra-music.zip
 http://81.169.246.181/ra-music.zip
 http://zoners.eu/openra/ra-music.zip

--- a/content/packages/ts-mirrors.txt
+++ b/content/packages/ts-mirrors.txt
@@ -3,12 +3,6 @@ http://srvdonate.ut.mephi.ru/openra/ts-packages.zip
 http://openra-mirror.ihptru.net/ts-packages.zip
 http://openra.baxxster.no/openra/ts-packages.zip
 http://openra.us.baxxster.no/openra/ts-packages.zip
-http://repo.anthonos.org/openra/ts-packages.zip
-http://ftp.nluug.nl/os/Linux/distr/anthon/openra/ts-packages.zip
-http://ftp.tsukuba.wide.ad.jp/Linux/anthon/openra/ts-packages.zip
-http://cdn.mirror.anthonos.org/openra/ts-packages.zip
-http://mirrors.ustc.edu.cn/anthon/openra/ts-packages.zip
-http://mirror.oss.maxcdn.com/anthonos/openra/ts-packages.zip
 http://81.169.246.181/ts-packages.zip
 http://zoners.eu/openra/ts-packages.zip
 http://178.63.32.174/ts-packages.zip


### PR DESCRIPTION
It doesn't look like they were moved. The repository is a bit too volatile and those non-free binary packages are not the place for Linux distribution mirrors anyway.