### PR TITLE
Added a Homebrew (cask) to Mac downloads

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -101,7 +101,9 @@ $(document).ready(function(){
     <li><%= generate_download_button("osx", GITHUB_RELEASE_ID, release_tag, sizes) %></li>
     <li><%= generate_download_button("osx", GITHUB_PLAYTEST_ID, playtest_tag, sizes) %></li>
   </ul>
-  <br />
+  <p>OpenRA is also available on <a href="https://caskroom.github.io/">Homebrew Cask</a>:</p>
+  <pre>$ brew cask install openra</pre>
+  <p class="downloadthirdparty">We do not directly maintain these external package sources, so there may be delays when a new version is released.<br />Please contact the downstream repository maintainers about any packaging issues.</p>
 </div>
 <div id="deb" class="tab">
   <hr />


### PR DESCRIPTION
Mac OS X apparently also has (community contributed) repositories and OpenRA is already in it.