### PR TITLE
Remove literal single quote from page title to avoid breaking Disqus

### DIFF
--- a/content/news/doomhammer-tournament-announcement.yaml
+++ b/content/news/doomhammer-tournament-announcement.yaml
@@ -1,6 +1,6 @@
 ---
 kind: article
-title: "Announcing Hecthor Doomhammer's Red Alert Tournament"
+title: "Announcing Hecthor Doomhammer&#39;s Red Alert Tournament"
 author: "Oliver Brakmann"
 created_at: 2016-06-21 22:00:00 +0200
 disqus_id: "hdTourney"


### PR DESCRIPTION
Edit: this ends up in the generated HTML:

```
   var disqus_title = 'Announcing Hecthor Doomhammer's Red Alert Tournament';
```