### PR TITLE
Fix a typo in the playtest-20160904 news post

### DIFF
--- a/content/news/playtest-20160904.md
+++ b/content/news/playtest-20160904.md
@@ -29,7 +29,7 @@ Other notable changes in this release include:
 
 Watch your back! We have taught the AI to use Engineers to capture tech buildings and enemy structures.
 <br />
-A controverial exploit allowing engineers to cancel production in the RA mod has also been fixed.
+A controversial exploit allowing engineers to cancel production in the RA mod has also been fixed.
 </div>
 
 


### PR DESCRIPTION
`controverial` wants to be `controversial` I guess.