### PR TITLE
Fixed typos in the Playtest 20161001 post

### DIFF
--- a/content/news/playtest-20161001.md
+++ b/content/news/playtest-20161001.md
@@ -25,9 +25,9 @@ Please be aware of the following two things when taking this playtest out for a 
 
 1. Because we have changed which assets are copied, all players coming from one of the previous *stable* releases will need to reinstall (or redownload) the assets for this playtest. These will be used for the future playtests and releases, so only needs to be done once.
 
-2. Please note that OpenRA now requires .NET 4.5 / Mono 3.2 or greater. Players using Ubuntu 12.04 or other Linux disributions that include Mono 2.10 can upgrade to a supported version by following the instructions on the [Mono site](http://www.mono-project.com/docs/getting-started/install/linux/#debian-ubuntu-and-derivatives). Windows XP users will need to upgrade to a supported OS.
+2. Please note that OpenRA now requires .NET 4.5 / Mono 3.2 or greater. Players using Ubuntu 12.04 or other Linux distributions that include Mono 2.10 can upgrade to a supported version by following the instructions on the [Mono site](http://www.mono-project.com/docs/getting-started/install/linux/#debian-ubuntu-and-derivatives). Windows XP users will need to upgrade to a supported OS.
 
-As usual, the installers for a variety of operating systems can be found on the [Download](/download) page. Please remember to report any bugs or issues you encounter on our [Github bug tracker](http://bugs.openra.net), in [our IRC channel](http://webchat.freenode.net/?channels=openra), on the [community forum](http://www.sleipnirstuff.com/forum/viewforum.php?f=80), or in the comment section below.
+As usual, the installers for a variety of operating systems can be found on the [Download](/download) page. Please remember to report any bugs or issues you encounter on our [GitHub bug tracker](http://bugs.openra.net), in [our IRC channel](http://webchat.freenode.net/?channels=openra), on the [community forum](http://www.sleipnirstuff.com/forum/viewforum.php?f=80), or in the comment section below.
 
 Thank you very much, and have fun!
 


### PR DESCRIPTION
I noticed as copy pasting to http://www.moddb.com/games/openra/news/playtest-20161001 gives me a spell checker in the text area.