### PR TITLE
Specify ruby 2.0 for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 # see travis-ci.org for details
 
 language: ruby
+rvm:
+  - 2.0
 
 # http://docs.travis-ci.com/user/migrating-from-legacy
 sudo: false


### PR DESCRIPTION
This works around the following error that we're now seeing on travis:
```
Gem::InstallError: octokit requires Ruby version >= 2.0.0.
An error occurred while installing octokit (4.4.1), and Bundler cannot continue.
```