### PR TITLE
Added a GitHub personal access token to increase the API rate limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ sudo: false
 env:
   global:
     secure: "Ot/NHtOO6W2pGcWAvXpdz3tKoppcvyZ3XlbPNMr/qOlRhcySMPB5wgkdZJFS3D+E5QoXeB+aOYuAW4dqm5R2bnwCoAnbgMrLItN6nejQ/CR5gejEHLrugoM5hXp0BuY/MUiRMkhj9ERMDIbwUulC2Zpsmx05Wq4q7+ZRBF451rE="
+    secure: "Pnr69KxTULnUQExsUWW/xPv8IY8uwPdJA0KM/fi9iPHlvAv/hUcTjhM8ZV1JQLJkApDKAJFpgeXn+vzgR/IJnmzlvIBqlbKMd2sk+JNhmgtu33E9Y3YnFPS3VrFQERjJpW5IGIRLHfhdXiNBIM0mmrPGJdGwu7aOeYEdoqfFeMQ="
 
 install:
 

--- a/lib/openra.rb
+++ b/lib/openra.rb
@@ -57,10 +57,19 @@ def generate_download_button(platform, github_id, tag, sizes)
   end
 end
 
+def github_auth()
+ if ENV.has_key?("GITHUB_OAUTH") then
+  client = Octokit::Client.new(:access_token => ENV['GITHUB_OAUTH'])
+  user = client.user
+  user.login
+ end
+end
+
 def fetch_package_sizes(gh_release_ids)
  require 'octokit'
  s = Hash.new
  if ENABLE_GITHUB_API then
+   github_auth()
    gh_release_ids.each do |id|
      if id == "" then next end
      assets = Octokit.release_assets('https://api.github.com/repos/OpenRA/OpenRA/releases/' + id)
@@ -75,6 +84,7 @@ end
 def fetch_git_tag(github_id)
   require 'octokit'
   if ENABLE_GITHUB_API and github_id != '' then
+    github_auth()
     asset = Octokit.release_asset('https://api.github.com/repos/OpenRA/OpenRA/releases/' + github_id)
     asset.tag_name
   else


### PR DESCRIPTION
Another attempt to fix https://github.com/OpenRA/OpenRAWeb/issues/324. The personal access token doesn't allow much otherwise than retrieving repo status (hopefully this is enough) but I still encrypted it, so this has to be tested outside a pull request in the Travis CI environment where it can be accessed.