### PR TITLE
Add a debian repository to the website

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -10,6 +10,7 @@ PLATFORMS = {
     "freebsd" => "FreeBSD",
 }
 
+create_debian_repository()
 playtest_tag = fetch_git_tag(GITHUB_PLAYTEST_ID)
 release_tag = fetch_git_tag(GITHUB_RELEASE_ID)
 sizes = fetch_package_sizes([GITHUB_RELEASE_ID, GITHUB_PLAYTEST_ID])

--- a/lib/openra.rb
+++ b/lib/openra.rb
@@ -87,5 +87,28 @@ def pretty_date(date)
 end
 
 def navigation_page(page)
-	page == @item.path || (page == "/news/" && @item.path.start_with?("/news/"))
+    page == @item.path || (page == "/news/" && @item.path.start_with?("/news/"))
+end
+
+def create_debian_repository()
+    require 'octokit'
+    require 'open-uri'
+    require 'fileutils'
+    FileUtils.mkdir_p('output/debian/packages')
+    Octokit.releases('OpenRA/OpenRA').each do |release|
+        release.assets.each do |asset|
+            if asset.content_type == "application/vnd.debian.binary-package" || asset.content_type == "application/x-debian-package" then
+                if !File.exists?("output/debian/packages/" + asset.name) then
+                    puts "Downloading .deb: " + asset.browser_download_url
+                    File.open("output/debian/packages/" + asset.name, "wb") do |output|
+                        open(asset.browser_download_url, "rb") do |input|
+                            output.write(input.read)
+                        end
+                    end
+                end
+            end
+	end
+    end
+    
+    system 'bash', '-c', 'pushd output/debian >/dev/null && dpkg-scanpackages -m packages/ > Packages'
 end


### PR DESCRIPTION
This includes a repository with all .deb packages into the website. Versions between 2011 and 2015 are missing from the response of the GitHub API so they are missing from the created repository too.

TODO list:
- [ ] Sign the Packages file to avoid warnings
- [ ] Add instructions to the download page