### PR TITLE
Authenticate with GitHub API to avoid rate limiting.

### DIFF
--- a/lib/openra.rb
+++ b/lib/openra.rb
@@ -61,6 +61,9 @@ def fetch_package_sizes(gh_release_ids)
  require 'octokit'
  s = Hash.new
  if ENABLE_GITHUB_API then
+   if ENV.has_key?("GITHUB_OAUTH") then
+    Octokit.access_token = ENV['GITHUB_OAUTH']
+   end
    gh_release_ids.each do |id|
      if id == "" then next end
      assets = Octokit.release_assets('https://api.github.com/repos/OpenRA/OpenRA/releases/' + id)
@@ -75,6 +78,9 @@ end
 def fetch_git_tag(github_id)
   require 'octokit'
   if ENABLE_GITHUB_API and github_id != '' then
+    if ENV.has_key?("GITHUB_OAUTH") then
+     Octokit.access_token = ENV['GITHUB_OAUTH']
+    end
     asset = Octokit.release_asset('https://api.github.com/repos/OpenRA/OpenRA/releases/' + github_id)
     asset.tag_name
   else


### PR DESCRIPTION
Fixes #324.

See this [testcase commit](https://github.com/pchote/OpenRAWeb/commit/0ac8a430d1003f7ed54d429882b6c292bcc837ac) and corresponding [travis log](https://travis-ci.org/pchote/OpenRAWeb/builds/286770263#L549) demonstrating it working on my local fork.
The reason #338 didn't work was because it authenticated a local `client` but then still called the API as the global unauthenticated user.  This PR instead authenticates globally.

I deleted the GitHub access tokens from previous attempts and generated a new one which I added via the Travis web UI.  This is much easier to set up than the ruby command line tool.

Note that encrypted environment variables aren't available when testing pull requests, so we expect this PR to fail with the standard rate limit error, but *not* with any other error.