### PR TITLE
Removed someone's dead/inactive mirror

### DIFF
--- a/content/packages/cnc-mirrors.txt
+++ b/content/packages/cnc-mirrors.txt
@@ -2,7 +2,6 @@ http://openra.ppmsite.com/cnc-packages.zip
 http://srvdonate.ut.mephi.ru/openra/cnc-packages.zip
 http://openra.baxxster.no/openra/cnc-packages.zip
 http://openra.us.baxxster.no/openra/cnc-packages.zip
-http://81.169.246.181/openra/cnc/cnc-packages.zip
 http://openra.0x47.net/cnc-packages.zip
 http://openra.mirror.haffdata.com/cnc-packages.zip
 http://galaxy.republic.community/h/openra/cnc-packages.zip

--- a/content/packages/cnc-music-mirrors.txt
+++ b/content/packages/cnc-music-mirrors.txt
@@ -2,7 +2,6 @@ http://openra.ppmsite.com/cnc-music.zip
 http://srvdonate.ut.mephi.ru/openra/cnc-music.zip
 http://openra.baxxster.no/openra/cnc-music.zip
 http://openra.us.baxxster.no/openra/cnc-music.zip
-http://81.169.246.181/openra/cnc/cnc-music.zip
 http://openra.0x47.net/cnc-music.zip
 http://openra.mirror.haffdata.com/cnc-music.zip
 http://galaxy.republic.community/h/openra/cnc-music.zip

--- a/content/packages/d2k-103-mirrors.txt
+++ b/content/packages/d2k-103-mirrors.txt
@@ -2,7 +2,6 @@ http://openra.ppmsite.com/d2k-103-packages.zip
 http://srvdonate.ut.mephi.ru/openra/d2k-103-packages.zip
 http://openra.baxxster.no/openra/d2k-103-packages.zip
 http://openra.us.baxxster.no/openra/d2k-103-packages.zip
-http://81.169.246.181/openra/d2k/d2k-103-packages.zip
 http://openra.0x47.net/d2k-103-packages.zip
 http://openra.mirror.haffdata.com/d2k-103-packages.zip
 http://galaxy.republic.community/h/openra/d2k-103-packages.zip

--- a/content/packages/d2k-base-mirrors.txt
+++ b/content/packages/d2k-base-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/d2k-base.zip
 http://openra.us.baxxster.no/openra/d2k-base.zip
 http://openra.ppmsite.com/d2k-base.zip
-http://81.169.246.181/openra/d2k/d2k-base.zip
 http://openra.mirror.haffdata.com/d2k-base.zip
 http://galaxy.republic.community/h/openra/d2k-base.zip

--- a/content/packages/d2k-patch106-mirrors.txt
+++ b/content/packages/d2k-patch106-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/d2k-patch106.zip
 http://openra.us.baxxster.no/openra/d2k-patch106.zip
 http://openra.ppmsite.com/d2k-patch106.zip
-http://81.169.246.181/openra/d2k/d2k-patch106.zip
 http://openra.mirror.haffdata.com/d2k-patch106.zip
 http://galaxy.republic.community/h/openra/d2k-patch106.zip

--- a/content/packages/d2k-quickinstall-mirrors.txt
+++ b/content/packages/d2k-quickinstall-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/d2k-quickinstall.zip
 http://openra.us.baxxster.no/openra/d2k-quickinstall.zip
 http://openra.ppmsite.com/d2k-quickinstall.zip
-http://81.169.246.181/openra/d2k/d2k-quickinstall.zip
 http://openra.mirror.haffdata.com/d2k-quickinstall.zip
 http://galaxy.republic.community/h/openra/d2k-quickinstall.zip

--- a/content/packages/ra-aftermath-mirrors.txt
+++ b/content/packages/ra-aftermath-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/ra-aftermath.zip
 http://openra.us.baxxster.no/openra/ra-aftermath.zip
 http://openra.ppmsite.com/ra-aftermath.zip
-http://81.169.246.181/openra/ra/ra-aftermath.zip
 http://openra.mirror.haffdata.com/ra-aftermath.zip
 http://galaxy.republic.community/h/openra/ra-aftermath.zip

--- a/content/packages/ra-base-mirrors.txt
+++ b/content/packages/ra-base-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/ra-base.zip
 http://openra.us.baxxster.no/openra/ra-base.zip
 http://openra.ppmsite.com/ra-base.zip
-http://81.169.246.181/openra/ra/ra-base.zip
 http://openra.mirror.haffdata.com/ra-base.zip
 http://galaxy.republic.community/h/openra/ra-base.zip

--- a/content/packages/ra-cncdesert-mirrors.txt
+++ b/content/packages/ra-cncdesert-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/ra-cncdesert.zip
 http://openra.us.baxxster.no/openra/ra-cncdesert.zip
 http://openra.ppmsite.com/ra-cncdesert.zip
-http://81.169.246.181/openra/ra/ra-cncdesert.zip
 http://openra.mirror.haffdata.com/ra-cncdesert.zip
 http://galaxy.republic.community/h/openra/ra-cncdesert.zip

--- a/content/packages/ra-mirrors.txt
+++ b/content/packages/ra-mirrors.txt
@@ -2,7 +2,6 @@ http://openra.ppmsite.com/ra-packages.zip
 http://srvdonate.ut.mephi.ru/openra/ra-packages.zip
 http://openra.baxxster.no/openra/ra-packages.zip
 http://openra.us.baxxster.no/openra/ra-packages.zip
-http://81.169.246.181/openra/ra/ra-packages.zip
 http://openra.0x47.net/ra-packages.zip
 http://openra.mirror.haffdata.com/ra-packages.zip
 http://galaxy.republic.community/h/openra/ra-packages.zip

--- a/content/packages/ra-music-mirrors.txt
+++ b/content/packages/ra-music-mirrors.txt
@@ -2,7 +2,6 @@ http://openra.ppmsite.com/ra-music.zip
 http://srvdonate.ut.mephi.ru/openra/ra-music.zip
 http://openra.baxxster.no/openra/ra-music.zip
 http://openra.us.baxxster.no/openra/ra-music.zip
-http://81.169.246.181/openra/ra/ra-music.zip
 http://openra.0x47.net/ra-music.zip
 http://openra.mirror.haffdata.com/ra-music.zip
 http://galaxy.republic.community/h/openra/ra-music.zip

--- a/content/packages/ra-quickinstall-mirrors.txt
+++ b/content/packages/ra-quickinstall-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/ra-quickinstall.zip
 http://openra.us.baxxster.no/openra/ra-quickinstall.zip
 http://openra.ppmsite.com/ra-quickinstall.zip
-http://81.169.246.181/openra/ra/ra-quickinstall.zip
 http://openra.mirror.haffdata.com/ra-quickinstall.zip
 http://galaxy.republic.community/h/openra/ra-quickinstall.zip

--- a/content/packages/ra-scores-mirrors.txt
+++ b/content/packages/ra-scores-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/ra-scores.zip
 http://openra.us.baxxster.no/openra/ra-scores.zip
 http://openra.ppmsite.com/ra-scores.zip
-http://81.169.246.181/openra/ra/ra-scores.zip
 http://openra.mirror.haffdata.com/ra-scores.zip
 http://galaxy.republic.community/h/openra/ra-scores.zip

--- a/content/packages/ts-mirrors.txt
+++ b/content/packages/ts-mirrors.txt
@@ -2,7 +2,6 @@ http://openra.ppmsite.com/ts-packages.zip
 http://srvdonate.ut.mephi.ru/openra/ts-packages.zip
 http://openra.baxxster.no/openra/ts-packages.zip
 http://openra.us.baxxster.no/openra/ts-packages.zip
-http://81.169.246.181/openra/ts/ts-packages.zip
 http://openra.0x47.net/ts-packages.zip
 http://openra.mirror.haffdata.com/ts-packages.zip
 http://galaxy.republic.community/h/openra/ts-packages.zip

--- a/content/packages/ts-music-mirrors.txt
+++ b/content/packages/ts-music-mirrors.txt
@@ -1,6 +1,5 @@
 http://openra.baxxster.no/openra/ts-music.zip
 http://openra.us.baxxster.no/openra/ts-music.zip
-http://81.169.246.181/openra/ts/ts-tsmusic.zip
 http://openra.0x47.net/ts-music.zip
 http://openra.mirror.haffdata.com/ts-music.zip
 http://galaxy.republic.community/h/openra/ts-music.zip


### PR DESCRIPTION
Upon attempting to download content files, users will receive a 404 error when the program selects this mirror, interrupting install.