### PR TITLE
Remove link to unmaintained Chocolatey package.

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -92,7 +92,6 @@ $(document).ready(function(){
     <li><%= generate_download_button("win", GITHUB_RELEASE_ID, release_tag, sizes) %></li>
     <li><%= generate_download_button("win", GITHUB_PLAYTEST_ID, playtest_tag, sizes) %></li>
   </ul>
-  <p>OpenRA is also available on <a href="https://chocolatey.org/packages/openra/">Chocolatey</a>.</p>
 </div>
 <div id="osx" class="tab">
   <hr />


### PR DESCRIPTION
Closes OpenRA/OpenRA#14294.