### PR TITLE
Generate a versions.json file with release info.

### DIFF
--- a/Rules
+++ b/Rules
@@ -32,6 +32,10 @@ compile 'sitemap' do
   filter :erb
 end
 
+compile 'versions' do
+  filter :erb
+end
+
 compile '/news/*/' do
     filter :kramdown
     layout 'news'
@@ -60,6 +64,10 @@ end
 
 route '/sitemap' do
   item.identifier.chop + '.xml'
+end
+
+route '/versions' do
+  item.identifier.chop + '.json'
 end
 
 route '/scripts/*' do

--- a/content/versions.html
+++ b/content/versions.html
@@ -1,0 +1,13 @@
+<%=
+# Generates a versions.json file that is consumed by the master server
+# to provide in-game version notifications
+# File will be renamed to versions.json during compilation
+require 'json'
+
+data = {
+  'release' => fetch_git_tag(GITHUB_RELEASE_ID),
+  'playtest' => GITHUB_PLAYTEST_ID != '' ? fetch_git_tag(GITHUB_PLAYTEST_ID) : '',
+  'known_versions' => fetch_git_tags(),
+}.to_json
+
+%>

--- a/lib/openra.rb
+++ b/lib/openra.rb
@@ -88,6 +88,18 @@ def fetch_git_tag(github_id)
   end
 end
 
+def fetch_git_tags()
+  require 'octokit'
+  if ENABLE_GITHUB_API then
+    if ENV.has_key?("GITHUB_OAUTH") then
+     Octokit.access_token = ENV['GITHUB_OAUTH']
+    end
+    Octokit.releases('OpenRA/OpenRA').map {|release| release.tag_name}
+  else
+    []
+  end
+end
+
 def pretty_date(date)
     attribute_to_time(date).strftime("%Y-%m-%d")
 end


### PR DESCRIPTION
This generates a `versions.json` file in the website root that is parsed by the master server to support the in-game version check.

The contents of the file looks like:
```
{
  "release": "release-20171014",
  "playtest": "",
  "known_versions": [
    "release-20171014",
    "playtest-20170930",
    "playtest-20170923",
    "playtest-20170902",
    "playtest-20170827",
    "playtest-20170722",
    "release-20170527",
    "release-20170421",
    "playtest-20170408",
    "playtest-20170304",
    "playtest-20170303",
    "release-20161019",
    "release-20161015",
    "playtest-20161001",
    "playtest-20160904",
    "release-20160508",
    "playtest-20160424",
    "playtest-20160403",
    "release-20151224",
    "playtest-20151213",
    "playtest-20151129",
    "playtest-20151114",
    "playtest-20151031",
    "release-20150919",
    "playtest-20150830",
    "playtest-20150808",
    "playtest-20150628",
    "release-20150614",
    "playtest-20150531",
    "playtest-20150524"
  ]
}
```