### PR TITLE
Update deb download notes

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -115,8 +115,6 @@ $(document).ready(function(){
     <li><%= generate_download_button("deb", GITHUB_RELEASE_ID, release_tag, sizes) %></li>
     <li><%= generate_download_button("deb", GITHUB_PLAYTEST_ID, playtest_tag, sizes) %></li>
   </ul>
-  <p>OpenRA is also available on <a href="http://www.playdeb.net/software/OpenRA">PlayDeb</a>.</p>
-  <p class="downloadthirdparty">We do not maintain this external package source, so there may be delays when a new version is released.<br />Please contact the downstream repository maintainers about any packaging issues.</p>
 </div>
 <div id="rpm" class="tab">
   <hr />

--- a/content/download.html
+++ b/content/download.html
@@ -109,6 +109,7 @@ $(document).ready(function(){
 <div id="deb" class="tab">
   <hr />
   <h3>Download OpenRA for Debian / Ubuntu</h3>
+  <p>OpenRA requires Mono 4.2 or greater. Ubuntu 14.04 and Debian Jessie users should use the official upstream <a href="http://www.mono-project.com/download/stable/#download-lin">Mono package repository</a> to upgrade their Mono installation.</p>
   <p>Download and run one of the packages below to install OpenRA via the Software Center.</p>
   <ul class="downloadlinks">
     <li><%= generate_download_button("deb", GITHUB_RELEASE_ID, release_tag, sizes) %></li>


### PR DESCRIPTION
* Adds a note about updating mono on older Ubuntu an Debian releases (see discussion in https://github.com/OpenRA/OpenRA/issues/14788).  I have already [updated the FAQ](https://github.com/OpenRA/OpenRA/wiki/FAQ) to match.
* Removes link to PlayDeb, which [appears to have died :cry:](http://www.playdeb.net/updates/) and is now missing our last two releases.
