### PR TITLE
Generate appimages.json for AppImage update router.

### DIFF
--- a/Rules
+++ b/Rules
@@ -36,6 +36,10 @@ compile 'versions' do
   filter :erb
 end
 
+compile 'appimages' do
+  filter :erb
+end
+
 compile '/news/*/' do
     filter :kramdown
     layout 'news'
@@ -67,6 +71,10 @@ route '/sitemap' do
 end
 
 route '/versions' do
+  item.identifier.chop + '.json'
+end
+
+route '/appimages' do
   item.identifier.chop + '.json'
 end
 

--- a/content/appimages.html
+++ b/content/appimages.html
@@ -1,0 +1,36 @@
+<%=
+# Generates an appimages.json file that is consumed by the master server
+# to support appimage update checks
+# File will be renamed to appimages.json during compilation
+require 'json'
+
+filename_map = {
+  'ra' => 'Red-Alert',
+  'cnc' => 'Tiberian-Dawn',
+  'd2k' => 'Dune-2000'
+}
+
+suffix_map = {
+  'release' => '',
+  'playtest' => '-playtest'
+}
+
+tag_map = {
+  'release' => fetch_git_tag(GITHUB_RELEASE_ID),
+  'playtest' => fetch_git_tag(GITHUB_PLAYTEST_ID != '' ? GITHUB_PLAYTEST_ID : GITHUB_RELEASE_ID)
+}
+
+data = Hash.new
+
+['release', 'playtest'].each do |channel|
+  tag = tag_map[channel]
+  data[channel] = Hash.new
+  ['ra', 'cnc', 'd2k'].each do |mod|
+    name = 'OpenRA-' + filename_map[mod] + suffix_map[channel] + '-x86_64.AppImage.zsync'
+    data[channel][mod] = DOWNLOAD_GITHUB_BASE_PATH + 'releases/download/' + tag + '/' + name
+  end
+end
+
+data.to_json
+
+%>


### PR DESCRIPTION
Like #369, but for the AppImage update metadata.  This implements separate release and playtest channels so that players who download a playtest will be updated to later playtests and then the next stable release, while players on the last stable release will go straight to the next one.

[Example json](http://sleipnirstuff.com/openra/appimages.json) generated by pointing the website compilation at my test releases.  The [appimagecheck script on the master server](https://github.com/OpenRA/OpenRAMasterServer/pull/54) is currently pointing to that test file.