### PR TITLE
Use anonymizeIp for Google Analytics.

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -33,6 +33,7 @@
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-48361645-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
     <!-- End Google Analytics -->


### PR DESCRIPTION
> When present, the IP address of the sender will be anonymized.

https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#anonymizeIp

The change will add the `&aip=1` parameter to the external request by GA.

https://support.google.com/analytics/answer/2763052?hl=en.



This change makes it easier to use the service under EU law.