### PR TITLE
Fix dark red text on black background

### DIFF
--- a/content/style.css
+++ b/content/style.css
@@ -544,7 +544,7 @@ pre {
 }
 
 .about-highlight {
-  color: #d92c2c;
+  color: #ffd300;
 }
 
 .about-modblock {


### PR DESCRIPTION
Changed about-highlight class to #ffd300 to match the Hammer and Sickle, as per #363