### PR TITLE
Correct the year in 'gamenews'

### DIFF
--- a/content/gamenews
+++ b/content/gamenews
@@ -1,4 +1,4 @@
-2019-02-01 20-00-00:
+2020-02-02 20-00-00:
 	Title: Release 20200202
 	Author: Paul Chote
 	Content: While we work on the next full playtest, there are a few serious issues that we wanted to address without further delay. Release 20200202 is now available, including:\n\n  • Fixes for significant performance issues\n  • Fixes for several rare crashes\n  • Fixes for aircraft behaviour issues\n  • Fixed several behaviour issues with unit and bot AI\n  • Fixed missing team chat in game replays\n  • Improved build icon layout in RA and D2k sidebars\n  • Improved in-game menu option layout\n\nVisit www.openra.net for more information and to download the new release. Good luck and have fun!


### PR DESCRIPTION
I also changed the date to the 2nd, since today (and therefore the day of the latest change) is the 2nd.
Reported by 'Schneckenhof' on Discord.