### PR TITLE
Previous mirror still works (path forwarding) - website name change

### DIFF
--- a/content/packages/cnc-mirrors.txt
+++ b/content/packages/cnc-mirrors.txt
@@ -3,4 +3,4 @@ http://srvdonate.ut.mephi.ru/openra/cnc-packages.zip
 http://openra.baxxster.no/openra/cnc-packages.zip
 http://openra.0x47.net/cnc-packages.zip
 http://openra.mirror.haffdata.com/cnc-packages.zip
-https://republic.community/hosted/files/command-and-conquer/openra/cnc-packages.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/cnc-packages.zip

--- a/content/packages/cnc-music-mirrors.txt
+++ b/content/packages/cnc-music-mirrors.txt
@@ -3,4 +3,4 @@ http://srvdonate.ut.mephi.ru/openra/cnc-music.zip
 http://openra.baxxster.no/openra/cnc-music.zip
 http://openra.0x47.net/cnc-music.zip
 http://openra.mirror.haffdata.com/cnc-music.zip
-https://republic.community/hosted/files/command-and-conquer/openra/cnc-music.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/cnc-music.zip

--- a/content/packages/d2k-base-mirrors.txt
+++ b/content/packages/d2k-base-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/d2k-base.zip
 http://openra.ppmsite.com/d2k-base.zip
 http://openra.mirror.haffdata.com/d2k-base.zip
-https://republic.community/hosted/files/command-and-conquer/openra/d2k-base.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/d2k-base.zip

--- a/content/packages/d2k-patch106-mirrors.txt
+++ b/content/packages/d2k-patch106-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/d2k-patch106.zip
 http://openra.ppmsite.com/d2k-patch106.zip
 http://openra.mirror.haffdata.com/d2k-patch106.zip
-https://republic.community/hosted/files/command-and-conquer/openra/d2k-patch106.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/d2k-patch106.zip

--- a/content/packages/d2k-quickinstall-mirrors.txt
+++ b/content/packages/d2k-quickinstall-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/d2k-quickinstall.zip
 http://openra.ppmsite.com/d2k-quickinstall.zip
 http://openra.mirror.haffdata.com/d2k-quickinstall.zip
-https://republic.community/hosted/files/command-and-conquer/openra/d2k-quickinstall.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/d2k-quickinstall.zip

--- a/content/packages/fs-mirrors.txt
+++ b/content/packages/fs-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.ppmsite.com/ts-expand.zip
 http://openra.mirror.haffdata.com/ts-expand.zip
 http://openra.baxxster.no/openra/ts-expand.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ts-expand.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ts-expand.zip

--- a/content/packages/fs-music-mirrors.txt
+++ b/content/packages/fs-music-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.ppmsite.com/ts-fsmusic.zip
 http://openra.mirror.haffdata.com/ts-fsmusic.zip
 http://openra.baxxster.no/openra/ts-fsmusic.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ts-fsmusic.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ts-fsmusic.zip

--- a/content/packages/ra-aftermath-mirrors.txt
+++ b/content/packages/ra-aftermath-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/ra-aftermath.zip
 http://openra.ppmsite.com/ra-aftermath.zip
 http://openra.mirror.haffdata.com/ra-aftermath.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ra-aftermath.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ra-aftermath.zip

--- a/content/packages/ra-base-mirrors.txt
+++ b/content/packages/ra-base-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/ra-base.zip
 http://openra.ppmsite.com/ra-base.zip
 http://openra.mirror.haffdata.com/ra-base.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ra-base.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ra-base.zip

--- a/content/packages/ra-cncdesert-mirrors.txt
+++ b/content/packages/ra-cncdesert-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/ra-cncdesert.zip
 http://openra.ppmsite.com/ra-cncdesert.zip
 http://openra.mirror.haffdata.com/ra-cncdesert.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ra-cncdesert.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ra-cncdesert.zip

--- a/content/packages/ra-mirrors.txt
+++ b/content/packages/ra-mirrors.txt
@@ -3,4 +3,4 @@ http://srvdonate.ut.mephi.ru/openra/ra-packages.zip
 http://openra.baxxster.no/openra/ra-packages.zip
 http://openra.0x47.net/ra-packages.zip
 http://openra.mirror.haffdata.com/ra-packages.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ra-packages.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ra-packages.zip

--- a/content/packages/ra-music-mirrors.txt
+++ b/content/packages/ra-music-mirrors.txt
@@ -3,4 +3,4 @@ http://srvdonate.ut.mephi.ru/openra/ra-music.zip
 http://openra.baxxster.no/openra/ra-music.zip
 http://openra.0x47.net/ra-music.zip
 http://openra.mirror.haffdata.com/ra-music.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ra-music.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ra-music.zip

--- a/content/packages/ra-quickinstall-mirrors.txt
+++ b/content/packages/ra-quickinstall-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/ra-quickinstall.zip
 http://openra.ppmsite.com/ra-quickinstall.zip
 http://openra.mirror.haffdata.com/ra-quickinstall.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ra-quickinstall.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ra-quickinstall.zip

--- a/content/packages/ra-scores-mirrors.txt
+++ b/content/packages/ra-scores-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/ra-scores.zip
 http://openra.ppmsite.com/ra-scores.zip
 http://openra.mirror.haffdata.com/ra-scores.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ra-scores.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ra-scores.zip

--- a/content/packages/ts-mirrors.txt
+++ b/content/packages/ts-mirrors.txt
@@ -3,4 +3,4 @@ http://srvdonate.ut.mephi.ru/openra/ts-packages.zip
 http://openra.baxxster.no/openra/ts-packages.zip
 http://openra.0x47.net/ts-packages.zip
 http://openra.mirror.haffdata.com/ts-packages.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ts-packages.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ts-packages.zip

--- a/content/packages/ts-music-mirrors.txt
+++ b/content/packages/ts-music-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.baxxster.no/openra/ts-music.zip
 http://openra.0x47.net/ts-music.zip
 http://openra.mirror.haffdata.com/ts-music.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ts-music.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ts-music.zip

--- a/content/packages/ts-quickinstall-mirrors.txt
+++ b/content/packages/ts-quickinstall-mirrors.txt
@@ -1,4 +1,4 @@
 http://openra.ppmsite.com/ts-quickinstall.zip
 http://openra.mirror.haffdata.com/ts-quickinstall.zip
 http://openra.baxxster.no/openra/ts-quickinstall.zip
-https://republic.community/hosted/files/command-and-conquer/openra/ts-quickinstall.zip
+https://thepublic.community/hosted/files/command-and-conquer/openra/ts-quickinstall.zip


### PR DESCRIPTION
Don't worry, my mirror never goes down, but my website name has changed, I'm updating to be proper.